### PR TITLE
Fix for issue #1536 to support multi-env setups

### DIFF
--- a/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
+++ b/UnitySDK/Assets/ML-Agents/Scripts/Academy.cs
@@ -321,7 +321,7 @@ namespace MLAgents
                 var pythonParameters = brainBatcher.SendAcademyParameters(academyParameters);
                 Random.InitState(pythonParameters.Seed);
                 Application.logMessageReceived += HandleLog;
-                logPath = Path.GetFullPath(".") + "/UnitySDK.log";
+                logPath = Path.GetFullPath(".") + "/UnitySDK_" + System.Guid.NewGuid().ToString() + ".log";
                 logWriter = new StreamWriter(logPath, false);
                 logWriter.WriteLine(System.DateTime.Now.ToString());
                 logWriter.WriteLine(" ");


### PR DESCRIPTION
Gym setups run multiple environment processes. Each environment process attempts to log to the same identical file causing access violations and failure of the academy to finish initialization. This change adds a unique identifier to the log file, while keeping it in the same folder users expect it to be.

Resolves issue #1536.